### PR TITLE
Enable ESP support in bess pipeline

### DIFF
--- a/core/modules/gtpu_parser.cc
+++ b/core/modules/gtpu_parser.cc
@@ -86,6 +86,11 @@ void GtpuParser::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
             set_gtp_parsing_attrs(&iph->src, &iph->dst, &udph->src_port,
                                   &udph->dst_port, (be32_t *)&teid,
                                   &old_iph->dst, &iph->protocol, p);
+          } else if (iph->protocol == Ipv4::kEsp) {
+            // ESP has no ports, encrypted payload
+            set_gtp_parsing_attrs(&iph->src, &iph->dst, (be16_t *)&_const_val,
+                                  (be16_t *)&_const_val, (be32_t *)&teid,
+                                  &old_iph->dst, &iph->protocol, p);
           } else {
             set_gtp_parsing_attrs(&iph->src, &iph->dst, (be16_t *)&_const_val,
                                   (be16_t *)&_const_val, (be32_t *)&teid,
@@ -98,6 +103,11 @@ void GtpuParser::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
         }
         break;
       case Ipv4::kIcmp: {
+        set_gtp_parsing_attrs(&iph->src, &iph->dst, (be16_t *)&_const_val,
+                              (be16_t *)&_const_val, (be32_t *)&_const_val,
+                              (be32_t *)&_const_val, &iph->protocol, p);
+      } break;
+      case Ipv4::kEsp: {
         set_gtp_parsing_attrs(&iph->src, &iph->dst, (be16_t *)&_const_val,
                               (be16_t *)&_const_val, (be32_t *)&_const_val,
                               (be32_t *)&_const_val, &iph->protocol, p);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**

> /kind enhancement

**What this PR does / why we need it**:
This PR extends the BESS pipeline to support ESP (Encapsulating Security Payload) protocol packets.
Currently, BESS only processes TCP, UDP, and ICMP packets. ESP packets are dropped at pdrLookup because they are not parsed and their attributes are not populated. This change ensures:
ESP packets are parsed correctly.
Required attributes are set for pdrLookup and subsequent modules.
ESP packets are no longer dropped silently and can be forwarded or processed as required.

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #9

**Test Report Added?**:
> /kind TESTED

**Test Report**:
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->

**Special notes for your reviewer**:
