### PR TITLE
Fix: Restore missing os.open to prevent FIFO blocking

### DIFF
--- a/bessctl/commands.py
+++ b/bessctl/commands.py
@@ -2014,6 +2014,7 @@ def _capture_gate(cli, module_name, direction, gate, opts, program, hook_fn):
     tmpdir = tempfile.mkdtemp()    
     fifo = os.path.join(tmpdir, "fifo")
     os.mkfifo(fifo, 0o600)              # FIFO with safe permissions
+    fd = os.open(fifo, os.O_RDWR)
 
     capture_cmd = [program]
     capture_cmd.extend(['-r', fifo])


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug fix

**What this PR does / why we need it**:
This PR ensures the FIFO is opened with os.O_RDWR immediately after creation.

This change is necessary to prevent the application from blocking (deadlocking) during initialization. By default, named pipes block until both a reader and a writer are connected. Opening the pipe with O_RDWR satisfies this condition immediately, acting as a keep-alive mechanism and allowing the main application thread to proceed without waiting for an external client to connect.

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [#24 ](https://github.com/5GC-DEV/bess-cdac/issues/24)

**Test Report Added?**:
> /kind TESTED


**Test Report**:
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->
NA

**Special notes for your reviewer**:
NIL